### PR TITLE
Clone only the branch we are trying to build

### DIFF
--- a/git-to-srpm.sh
+++ b/git-to-srpm.sh
@@ -74,7 +74,7 @@ fi
 test -d ${pkg} && rm -Rf ${pkg}
 
 # Git clone 
-git clone ${git_url}/r/rpms/${pkg}.git
+git clone -b ${git_branch} --single-branch ${git_url}/r/rpms/${pkg}.git
 cd ${pkg}
 git checkout ${git_branch}
 test -d ~/git/centos-git-common || (mkdir ~/git; pushd ~/git ; git clone https://git.centos.org/r/centos-git-common.git ; popd)


### PR DESCRIPTION
$ time git clone -b c7-sig-altarch-kernel --single-branch https://git.stg.centos.org/r/rpms/kernel.git
Cloning into 'kernel'...
remote: Welcome to repoSpanner 0.4+1.f38383546f7ce0e88ec7b9c5bf7959521af2c941.el7.infra, node centos01.rpms.stg.fedoraproject.org
Receiving objects: 100% (105/105), 905.74 KiB | 0 bytes/s, done.

real	0m1.712s
user	0m0.376s
sys	0m0.313s

$ time git clone https://git.stg.centos.org/r/rpms/kernel.git
Cloning into 'kernel'...
fatal: The remote end hung up unexpectedly
fatal: protocol error: bad pack header

real	10m6.008s
user	0m0.008s
sys	0m0.000s
